### PR TITLE
Open social links in new tab and add alt text

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -17,10 +17,10 @@ export const Footer = () => {
           </Col>
           <Col size={12} sm={6} className="text-center text-sm-end">
             <div className="social-icon">
-            <a href="https://www.linkedin.com/in/chaitanya-sagar-4aa755159/"><img src={navIcon1} alt="" /></a>
-            <a href="https://github.com/chaitanyasagar3"><img src={NavIcon4} alt=""/></a>
-            <a href="https://www.facebook.com/chetusagar98/"><img src={navIcon2} alt="" /></a>
-            <a href="https://www.instagram.com/ichaitanya_sagar/"><img src={navIcon3} alt="" /></a>
+            <a href="https://www.linkedin.com/in/chaitanya-sagar-4aa755159/" target="_blank" rel="noopener noreferrer"><img src={navIcon1} alt="LinkedIn" /></a>
+            <a href="https://github.com/chaitanyasagar3" target="_blank" rel="noopener noreferrer"><img src={NavIcon4} alt="GitHub"/></a>
+            <a href="https://www.facebook.com/chetusagar98/" target="_blank" rel="noopener noreferrer"><img src={navIcon2} alt="Facebook" /></a>
+            <a href="https://www.instagram.com/ichaitanya_sagar/" target="_blank" rel="noopener noreferrer"><img src={navIcon3} alt="Instagram" /></a>
 
             </div>
             <p>Copyright 2022. All Rights Reserved</p>

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -53,10 +53,10 @@ export const NavBar = () => {
             </Nav>
             <span className="navbar-text">
               <div className="social-icon">
-                <a href="https://www.linkedin.com/in/chaitanya-sagar-4aa755159/"><img src={NavIcon1} alt="" /></a>
-                <a href="https://github.com/chaitanyasagar3"><img src={NavIcon4} alt=""/></a>
-                <a href="https://www.facebook.com/chetusagar98/"><img src={NavIcon2} alt="" /></a>
-                <a href="https://www.instagram.com/ichaitanya_sagar/"><img src={NavIcon3} alt="" /></a>
+                <a href="https://www.linkedin.com/in/chaitanya-sagar-4aa755159/" target="_blank" rel="noopener noreferrer"><img src={NavIcon1} alt="LinkedIn" /></a>
+                <a href="https://github.com/chaitanyasagar3" target="_blank" rel="noopener noreferrer"><img src={NavIcon4} alt="GitHub"/></a>
+                <a href="https://www.facebook.com/chetusagar98/" target="_blank" rel="noopener noreferrer"><img src={NavIcon2} alt="Facebook" /></a>
+                <a href="https://www.instagram.com/ichaitanya_sagar/" target="_blank" rel="noopener noreferrer"><img src={NavIcon3} alt="Instagram" /></a>
               </div>
               <HashLink to='#connect'>
                 <button className="vvd"><span>Let’s Connect</span></button>


### PR DESCRIPTION
## Summary
- Social media links in the navbar and footer now open in a new tab with `rel="noopener noreferrer"`, preventing reverse-tabnabbing on external links
- Added descriptive `alt` text to social icons for accessibility

## Test plan
- [ ] Click each social icon and confirm it opens in a new tab